### PR TITLE
FFS-2054: Fiks race condition ved opprettelse av ny bruker

### DIFF
--- a/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
@@ -4,11 +4,12 @@ import no.novari.flyt.authorization.user.kafka.UserPermission
 import no.novari.flyt.authorization.user.kafka.UserPermissionEntityProducerService
 import no.novari.flyt.authorization.user.model.User
 import no.novari.flyt.authorization.user.model.UserEntity
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class UserService(
@@ -31,13 +32,23 @@ class UserService(
         }
     }
 
-    fun save(user: User) {
-        val userEntity = userRepository.save(mapFromUser(user))
-        userPermissionEntityProducerService.send(mapFromEntityToUserPermission(userEntity))
-    }
+    fun findOrCreate(user: User): User {
+        userRepository.findByObjectIdentifier(user.objectIdentifier)?.let {
+            return mapFromEntity(it)
+        }
 
-    fun find(objectIdentifier: UUID): User? {
-        return userRepository.findByObjectIdentifier(objectIdentifier)?.let(::mapFromEntity)
+        return try {
+            val savedEntity = userRepository.saveAndFlush(mapFromUser(user))
+            userPermissionEntityProducerService.send(mapFromEntityToUserPermission(savedEntity))
+            mapFromEntity(savedEntity)
+        } catch (exception: DataIntegrityViolationException) {
+            val existing = userRepository.findByObjectIdentifier(user.objectIdentifier) ?: throw exception
+            logger.info(
+                "Lost race when creating user with objectIdentifier={}; returning existing user",
+                user.objectIdentifier,
+            )
+            mapFromEntity(existing)
+        }
     }
 
     fun getAll(pageable: Pageable): Page<User> {
@@ -88,6 +99,6 @@ class UserService(
     }
 
     private companion object {
-        val logger = LoggerFactory.getLogger(UserService::class.java)
+        val logger: Logger = LoggerFactory.getLogger(UserService::class.java)
     }
 }

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/MeController.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/MeController.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.util.UUID
 
 @RestController
 @RequestMapping("$INTERNAL_API/authorization/me")
@@ -25,10 +24,8 @@ class MeController(
     @GetMapping("is-authorized")
     fun checkAuthorization(authentication: Authentication?): String {
         val jwtAuthToken = requireJwtAuthenticationToken(authentication)
-        if (getUserFromUserAuthorizationComponent(jwtAuthToken) == null &&
-            tokenParsingUtils.hasPermittedRole(jwtAuthToken)
-        ) {
-            createUserFromToken(authentication)
+        if (tokenParsingUtils.hasPermittedRole(jwtAuthToken)) {
+            userService.findOrCreate(buildUserFromToken(jwtAuthToken, authentication))
         }
 
         return "User authorized"
@@ -44,26 +41,19 @@ class MeController(
     @GetMapping
     fun get(authentication: Authentication?): User {
         val jwtAuthToken = requireJwtAuthenticationToken(authentication)
-
-        return getUserFromUserAuthorizationComponent(jwtAuthToken) ?: createUserFromToken(authentication)
+        return userService.findOrCreate(buildUserFromToken(jwtAuthToken, authentication))
     }
 
-    private fun getUserFromUserAuthorizationComponent(token: JwtAuthenticationToken): User? {
-        return userService.find(UUID.fromString(tokenParsingUtils.getObjectIdentifierFromToken(token)))
-    }
-
-    private fun createUserFromToken(authentication: Authentication?): User {
-        val jwtAuthToken = requireJwtAuthenticationToken(authentication)
+    private fun buildUserFromToken(
+        jwtAuthToken: JwtAuthenticationToken,
+        authentication: Authentication?,
+    ): User {
         val user = tokenParsingUtils.getUserFromToken(jwtAuthToken)
-        val newUser =
-            if (tokenParsingUtils.isAdmin(authentication)) {
-                user.copy(sourceApplicationIds = allSourceApplicationIds())
-            } else {
-                user
-            }
-
-        userService.save(newUser)
-        return newUser
+        return if (tokenParsingUtils.isAdmin(authentication)) {
+            user.copy(sourceApplicationIds = allSourceApplicationIds())
+        } else {
+            user
+        }
     }
 
     private fun allSourceApplicationIds(): List<Long> {

--- a/src/test/kotlin/no/novari/flyt/authorization/user/UserServiceTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/UserServiceTest.kt
@@ -1,0 +1,149 @@
+package no.novari.flyt.authorization.user
+
+import no.novari.flyt.authorization.user.kafka.UserPermission
+import no.novari.flyt.authorization.user.kafka.UserPermissionEntityProducerService
+import no.novari.flyt.authorization.user.model.User
+import no.novari.flyt.authorization.user.model.UserEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.dao.DataIntegrityViolationException
+import java.util.UUID
+
+class UserServiceTest {
+    @Test
+    fun `findOrCreate returns existing user without inserting or publishing`() {
+        val objectIdentifier = UUID.randomUUID()
+        val existing =
+            UserEntity(
+                objectIdentifier = objectIdentifier,
+                name = "Existing",
+                email = "existing@novari.no",
+                sourceApplicationIds = mutableListOf(1L),
+            ).apply { id = 1L }
+
+        val repository =
+            mock<UserRepository> {
+                on { findByObjectIdentifier(objectIdentifier) } doReturn existing
+            }
+        val producer = mock<UserPermissionEntityProducerService>()
+        val service = UserService(repository, producer)
+
+        val result =
+            service.findOrCreate(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = "From token",
+                    email = "token@novari.no",
+                    sourceApplicationIds = listOf(1L),
+                ),
+            )
+
+        assertEquals(objectIdentifier, result.objectIdentifier)
+        assertEquals("Existing", result.name)
+        verify(repository, never()).saveAndFlush(any<UserEntity>())
+        verify(producer, never()).send(any())
+    }
+
+    @Test
+    fun `findOrCreate inserts and publishes when user is missing`() {
+        val objectIdentifier = UUID.randomUUID()
+        val repository =
+            mock<UserRepository> {
+                on { findByObjectIdentifier(objectIdentifier) } doReturn null
+                on { saveAndFlush(any<UserEntity>()) } doAnswer { invocation ->
+                    (invocation.arguments[0] as UserEntity).apply { id = 7L }
+                }
+            }
+        val producer = mock<UserPermissionEntityProducerService>()
+        val service = UserService(repository, producer)
+
+        val result =
+            service.findOrCreate(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = "New user",
+                    email = "new@novari.no",
+                    sourceApplicationIds = listOf(2L, 3L),
+                ),
+            )
+
+        assertEquals(objectIdentifier, result.objectIdentifier)
+        assertEquals("New user", result.name)
+        assertEquals(listOf(2L, 3L), result.sourceApplicationIds)
+        verify(repository).saveAndFlush(any<UserEntity>())
+        verify(producer).send(UserPermission(objectIdentifier, listOf(2L, 3L)))
+    }
+
+    @Test
+    fun `findOrCreate returns winning row when insert hits unique constraint after losing race`() {
+        val objectIdentifier = UUID.randomUUID()
+        val winningRow =
+            UserEntity(
+                objectIdentifier = objectIdentifier,
+                name = "Winner",
+                email = "winner@novari.no",
+                sourceApplicationIds = mutableListOf(5L),
+            ).apply { id = 99L }
+
+        val repository =
+            mock<UserRepository> {
+                on { findByObjectIdentifier(objectIdentifier) } doReturn null doReturn winningRow
+                on {
+                    saveAndFlush(any<UserEntity>())
+                } doThrow DataIntegrityViolationException("uk_td2dvdf4t2le4cydfk7a1x17i")
+            }
+        val producer = mock<UserPermissionEntityProducerService>()
+        val service = UserService(repository, producer)
+
+        val result =
+            service.findOrCreate(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = "Loser",
+                    email = "loser@novari.no",
+                    sourceApplicationIds = listOf(1L),
+                ),
+            )
+
+        assertEquals(objectIdentifier, result.objectIdentifier)
+        assertEquals("Winner", result.name)
+        assertEquals(listOf(5L), result.sourceApplicationIds)
+        verify(repository, times(2)).findByObjectIdentifier(objectIdentifier)
+        verify(producer, never()).send(any())
+    }
+
+    @Test
+    fun `findOrCreate rethrows when insert fails and refetch still finds nothing`() {
+        val objectIdentifier = UUID.randomUUID()
+        val repository =
+            mock<UserRepository> {
+                on { findByObjectIdentifier(objectIdentifier) } doReturn null
+                on {
+                    saveAndFlush(any<UserEntity>())
+                } doThrow DataIntegrityViolationException("some other constraint")
+            }
+        val producer = mock<UserPermissionEntityProducerService>()
+        val service = UserService(repository, producer)
+
+        assertThrows(DataIntegrityViolationException::class.java) {
+            service.findOrCreate(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = "X",
+                    email = "x@novari.no",
+                    sourceApplicationIds = listOf(1L),
+                ),
+            )
+        }
+        verify(producer, never()).send(any())
+    }
+}


### PR DESCRIPTION
## Summary

- Frontend fyrer `GET /me` og `GET /me/is-authorized` i parallell ved første innlogging (`Main.tsx`-mount). Begge endepunktene hadde sin egen find-or-create-logikk uten synkronisering, så for en bruker som ikke fantes fra før kunne begge tråder passere find-sjekken og forsøke samme `INSERT` — andre `INSERT` traff unique-constraint `UK_td2dvdf4t2le4cydfk7a1x17i` på `object_identifier` og kastet `DataIntegrityViolationException` (SQLState 23505).
- Flytter find-or-create-mønsteret inn i `UserService.findOrCreate`. Strategien er optimistisk insert med fallback: forsøk `saveAndFlush`, og hvis vi taper race-en fanges `DataIntegrityViolationException` og raden hentes på nytt. Ingen DB-spesifikk `ON CONFLICT`, ingen tilleggslås — virker også med flere replikaer dersom det blir aktuelt senere.
- Kafka-publiseringen flyttes inn i `findOrCreate` slik at `UserPermission`-eventet bare sendes når denne tråden faktisk opprettet brukeren. Tidligere ville en vunnet race ha publisert to ganger.
- `MeController.checkAuthorization` og `MeController.get` bruker nå begge `findOrCreate`. Eksisterende semantikk er bevart: `/is-authorized` oppretter fortsatt kun når `hasPermittedRole` er sann, og admin får fortsatt alle `sourceApplicationIds` via `buildUserFromToken` før kallet.
- Ny `UserServiceTest` dekker fire stier i `findOrCreate`: eksisterende bruker (ingen insert, ingen publisering), ny bruker (insert + publisering), tapt race (re-fetch, ingen publisering), og rethrow når re-fetch fortsatt returnerer null.

Jira: FFS-2054