### PR TITLE
FFS-2114: Add internal client user lookup endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Spring Boot service that persists Flyt user permissions, answers client authoriz
 
 ## Highlights
 
-- **Internal OAuth2 APIs** — web-resource-server profile locks down `/api/intern/authorization` endpoints and enforces admin roles for management actions.
+- **Internal OAuth2 APIs** — web-resource-server profile locks down `/api/intern/authorization` for users/admins and `/api/intern-klient/authorization/brukere` for authorized OAuth2 clients.
 - **Kafka request/reply** — listens for `client-id` authorization requests and replies with source application mappings using the FINT Kafka request/reply utilities.
 - **Permission sync** — persists users in Postgres and emits `userpermission` entity events whenever users are created, updated, or bulk-synced.
 - **Permission auditing** — keeps an Envers history of `user_entity` and `sourceApplicationIds` changes in dedicated audit tables with actor metadata.
@@ -23,6 +23,7 @@ Spring Boot service that persists Flyt user permissions, answers client authoriz
 | `UserPermissionEntityProducerService` | Produces last-value `userpermission` events to Kafka with a 4-day retention window. |
 | `UserPublishingComponent` | Conditional scheduler that republishes all users at configured intervals. |
 | `UserController` | Admin-only internal API for paginating users and bulk updating `sourceApplicationIds`. |
+| `InternalClientUserController` | Client-credentials protected internal client API for single and batch user lookups by `objectIdentifier`. |
 | `MeController` | Self-service internal API that provisions users from JWT claims, reports restricted-page access, and returns the current user. |
 | `TokenParsingUtils` / `AccessControlProperties` | Parse JWT claims, check permitted app roles, and detect `ROLE_ADMIN` authority. |
 
@@ -39,6 +40,13 @@ Base path: `/api/intern/authorization`
 | `POST` | `/users/actions/userPermissionBatchPut` | Admin-only bulk upsert of user permissions, then republishes all users. | JSON array of `User` objects (`objectIdentifier`, `email`, `name`, `sourceApplicationIds`). | `200 OK` or `403` on insufficient role. |
 
 Errors are surfaced as standard Spring MVC responses (`403 Forbidden` when the caller lacks admin authority).
+
+Base path: `/api/intern-klient/authorization/brukere`
+
+| Method | Path | Description | Request body | Response |
+| --- | --- | --- | --- | --- |
+| `GET` | `/{objectIdentifier}` | Returns a single `User` by object identifier. | – | `200 OK` with `User` JSON or `404 Not Found`. |
+| `POST` | `/actions/lookup` | Returns all matching users for a batch of object identifiers. | JSON array of UUIDs. | `200 OK` with `List<User>`. |
 
 ## Kafka Integration
 
@@ -59,6 +67,7 @@ Key properties:
 | Property | Description |
 | --- | --- |
 | `fint.application-id` | Defaults to `fint-flyt-authorization-service`. |
+| `fint.flyt.authorization.sso.client-id` | Client ID allowed to call `/api/intern-klient/authorization/brukere`. |
 | `novari.flyt.authorization.access-control.permitted-approles.*` | Map of allowed app roles (e.g., `flyt-user`, `flyt-developer`) to role URIs used when onboarding users. |
 | `novari.flyt.authorization.access-control.enabled` | Enables the scheduled user-permission publisher. |
 | `novari.flyt.authorization.access-control.sync-schedule.initial-delay-ms` / `fixed-delay-ms` | Interval settings for the publisher task. |
@@ -67,6 +76,7 @@ Key properties:
 | `spring.datasource.*` | JDBC details for Postgres; Flyway migrations live under `classpath:db/migration`. |
 | `spring.security.oauth2.resourceserver.jwt.issuer-uri` | OAuth issuer for protecting internal endpoints. |
 | `novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json` | Defines which org/role pairs may call internal APIs (injected by overlays). |
+| `novari.flyt.web-resource-server.security.api.internal-client.authorized-client-ids` | Defines which OAuth2 client IDs may call the internal client API. |
 | `spring.kafka.consumer.group-id` | Defaults to the application ID. |
 
 Secrets referenced by Kustomize overlays must provide database credentials, OAuth settings, Kafka access, and SSO client IDs. The service now binds only `fint.flyt.<app>.sso.client-id` from these secrets; `client-secret` values are not injected into the application environment.
@@ -114,6 +124,7 @@ The script injects namespace-specific values (base paths, Kafka topics, authoriz
 
 - Uses the FINT OAuth2 web-resource-server setup for JWT validation (`spring.security.oauth2.resourceserver.jwt.issuer-uri`).
 - Internal APIs are restricted to callers whose org/role pairs are configured; management endpoints additionally require `ROLE_ADMIN`.
+- Internal client APIs are restricted to configured OAuth2 client IDs and are intended for `client_credentials` callers.
 - Client-authorization replies are limited to explicitly configured SSO client IDs per source application.
 
 ## Observability & Operations
@@ -142,4 +153,3 @@ The script injects namespace-specific values (base paths, Kafka topics, authoriz
 4. Add or adjust tests for any new behaviour or edge cases.
 
 FINT Flyt Authorization Service is maintained by the FINT Flyt team. Reach out via the internal Slack channel or open an issue in this repository for questions or enhancements.
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Spring Boot service that persists Flyt user permissions, answers client authoriz
 
 ## Highlights
 
-- **Internal OAuth2 APIs** — web-resource-server profile locks down `/api/intern/authorization` for users/admins and `/api/intern-klient/authorization/brukere` for authorized OAuth2 clients.
+- **Internal OAuth2 APIs** — web-resource-server profile locks down `/api/intern/authorization` for users/admins and `/api/intern-klient/authorization/users` for authorized OAuth2 clients.
 - **Kafka request/reply** — listens for `client-id` authorization requests and replies with source application mappings using the FINT Kafka request/reply utilities.
 - **Permission sync** — persists users in Postgres and emits `userpermission` entity events whenever users are created, updated, or bulk-synced.
 - **Permission auditing** — keeps an Envers history of `user_entity` and `sourceApplicationIds` changes in dedicated audit tables with actor metadata.
@@ -41,7 +41,7 @@ Base path: `/api/intern/authorization`
 
 Errors are surfaced as standard Spring MVC responses (`403 Forbidden` when the caller lacks admin authority).
 
-Base path: `/api/intern-klient/authorization/brukere`
+Base path: `/api/intern-klient/authorization/users`
 
 | Method | Path | Description | Request body | Response |
 | --- | --- | --- | --- | --- |
@@ -67,7 +67,7 @@ Key properties:
 | Property | Description |
 | --- | --- |
 | `fint.application-id` | Defaults to `fint-flyt-authorization-service`. |
-| `fint.flyt.authorization.sso.client-id` | Client ID allowed to call `/api/intern-klient/authorization/brukere`. |
+| `fint.flyt.authorization.sso.client-id` | Client ID allowed to call `/api/intern-klient/authorization/users`. |
 | `novari.flyt.authorization.access-control.permitted-approles.*` | Map of allowed app roles (e.g., `flyt-user`, `flyt-developer`) to role URIs used when onboarding users. |
 | `novari.flyt.authorization.access-control.enabled` | Enables the scheduled user-permission publisher. |
 | `novari.flyt.authorization.access-control.sync-schedule.initial-delay-ms` / `fixed-delay-ms` | Interval settings for the publisher task. |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-core")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.2.3")
     testRuntimeOnly("com.h2database:h2")
     add("mockitoAgent", "org.mockito:mockito-core")

--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -54,6 +54,11 @@ spec:
         secretKeyRef:
           name: fint-flyt-hmsreg-oauth2-client
           key: fint.flyt.hmsreg.sso.client-id
+    - name: fint.flyt.authorization.sso.client-id
+      valueFrom:
+        secretKeyRef:
+          name: fint-flyt-authorization-oauth2-client
+          key: fint.sso.client-id
   resources:
     limits:
       memory: "1024Mi"

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - flais.yaml
+  - oauth2-authorization-client.yaml
   - vigo-oauth2-client.yaml
   - hmsreg-oauth2-client.yaml
   - altinn-onepassword.yaml

--- a/kustomize/base/oauth2-authorization-client.yaml
+++ b/kustomize/base/oauth2-authorization-client.yaml
@@ -1,0 +1,7 @@
+apiVersion: "fintlabs.no/v1alpha1"
+kind: NamOAuthClientApplicationResource
+metadata:
+  name: fint-flyt-authorization-oauth2-client
+spec:
+  grantTypes:
+    - client_credentials

--- a/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
@@ -40,6 +40,10 @@ class UserService(
         return userRepository.findByObjectIdentifier(objectIdentifier)?.let(::mapFromEntity)
     }
 
+    fun findAllByObjectIdentifiers(objectIdentifiers: Collection<UUID>): List<User> {
+        return userRepository.findAllByObjectIdentifierIn(objectIdentifiers).map(::mapFromEntity)
+    }
+
     fun getAll(pageable: Pageable): Page<User> {
         return userRepository.findAll(pageable).map(::mapFromEntity)
     }

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
@@ -14,7 +14,7 @@ import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
 @RestController
-@RequestMapping("$INTERNAL_CLIENT_API/authorization/brukere")
+@RequestMapping("$INTERNAL_CLIENT_API/authorization/users")
 class InternalClientUserController(
     private val userService: UserService,
 ) {

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
@@ -1,0 +1,35 @@
+package no.novari.flyt.authorization.user.controller
+
+import no.novari.flyt.authorization.user.UserService
+import no.novari.flyt.authorization.user.model.User
+import no.novari.flyt.webresourceserver.UrlPaths.INTERNAL_CLIENT_API
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("$INTERNAL_CLIENT_API/authorization/brukere")
+class InternalClientUserController(
+    private val userService: UserService,
+) {
+    @GetMapping("/{objectIdentifier}")
+    fun get(
+        @PathVariable objectIdentifier: UUID,
+    ): User {
+        return userService.find(objectIdentifier)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
+    }
+
+    @PostMapping("/actions/lookup")
+    fun lookup(
+        @RequestBody objectIdentifiers: List<UUID>,
+    ): List<User> {
+        return userService.findAllByObjectIdentifiers(objectIdentifiers)
+    }
+}

--- a/src/main/resources/application-flyt-web-resource-server.yaml
+++ b/src/main/resources/application-flyt-web-resource-server.yaml
@@ -5,3 +5,5 @@ novari:
         api:
           internal:
             enabled: true
+          internal-client:
+            enabled: true

--- a/src/main/resources/application-local-staging.yaml
+++ b/src/main/resources/application-local-staging.yaml
@@ -1,5 +1,9 @@
 fint:
   org-id: novari.no
+  flyt:
+    authorization:
+      sso:
+        client-id: local-authorization-client
 
 novari:
   flyt:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,11 @@ novari:
         sync-schedule:
           initial-delay: 1s
           fixed-delay: 12h
+    web-resource-server:
+      security:
+        api:
+          internal-client:
+            authorized-client-ids: ${fint.flyt.authorization.sso.client-id}
 
 spring:
   profiles:

--- a/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.core.annotation.Order
@@ -22,6 +21,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -37,16 +37,16 @@ class InternalClientUserControllerTest
         private val mockMvc: MockMvc,
         private val objectMapper: ObjectMapper,
     ) {
-        @MockBean
+        @MockitoBean
         private lateinit var userService: UserService
 
-        @MockBean
+        @MockitoBean
         private lateinit var tokenParsingUtils: TokenParsingUtils
 
-        @MockBean
+        @MockitoBean
         private lateinit var jwtDecoder: JwtDecoder
 
-        @MockBean
+        @MockitoBean
         private lateinit var sourceApplicationJwtConverter: SourceApplicationJwtConverter
 
         @Test

--- a/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
@@ -62,7 +62,7 @@ class InternalClientUserControllerTest
 
             mockMvc
                 .perform(
-                    get("/api/intern-klient/authorization/brukere/$objectIdentifier")
+                    get("/api/intern-klient/authorization/users/$objectIdentifier")
                         .with(internalClientJwt()),
                 ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.objectIdentifier").value(objectIdentifier.toString()))
@@ -77,7 +77,7 @@ class InternalClientUserControllerTest
 
             mockMvc
                 .perform(
-                    get("/api/intern-klient/authorization/brukere/$objectIdentifier")
+                    get("/api/intern-klient/authorization/users/$objectIdentifier")
                         .with(internalClientJwt()),
                 ).andExpect(status().isNotFound)
         }
@@ -96,7 +96,7 @@ class InternalClientUserControllerTest
 
             mockMvc
                 .perform(
-                    post("/api/intern-klient/authorization/brukere/actions/lookup")
+                    post("/api/intern-klient/authorization/users/actions/lookup")
                         .with(internalClientJwt())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(listOf(first, second, third))),
@@ -114,7 +114,7 @@ class InternalClientUserControllerTest
 
             mockMvc
                 .perform(
-                    post("/api/intern-klient/authorization/brukere/actions/lookup")
+                    post("/api/intern-klient/authorization/users/actions/lookup")
                         .with(internalClientJwt())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(emptyList<UUID>())),
@@ -126,7 +126,7 @@ class InternalClientUserControllerTest
         fun `lookup returns bad request for invalid json`() {
             mockMvc
                 .perform(
-                    post("/api/intern-klient/authorization/brukere/actions/lookup")
+                    post("/api/intern-klient/authorization/users/actions/lookup")
                         .with(internalClientJwt())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{invalid"),
@@ -136,7 +136,7 @@ class InternalClientUserControllerTest
         @Test
         fun `internal client endpoint returns unauthorized without authorization header`() {
             mockMvc
-                .perform(get("/api/intern-klient/authorization/brukere/${UUID.randomUUID()}"))
+                .perform(get("/api/intern-klient/authorization/users/${UUID.randomUUID()}"))
                 .andExpect(status().isUnauthorized)
         }
 
@@ -144,7 +144,7 @@ class InternalClientUserControllerTest
         fun `internal client endpoint rejects ordinary user token`() {
             mockMvc
                 .perform(
-                    get("/api/intern-klient/authorization/brukere/${UUID.randomUUID()}")
+                    get("/api/intern-klient/authorization/users/${UUID.randomUUID()}")
                         .with(userJwt()),
                 ).andExpect(status().isForbidden)
         }

--- a/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
@@ -1,0 +1,223 @@
+package no.novari.flyt.authorization.user.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import no.novari.flyt.authorization.user.UserService
+import no.novari.flyt.authorization.user.controller.utils.TokenParsingUtils
+import no.novari.flyt.authorization.user.model.User
+import no.novari.flyt.webresourceserver.security.client.sourceapplication.SourceApplicationJwtConverter
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.core.annotation.Order
+import org.springframework.data.domain.PageImpl
+import org.springframework.http.MediaType
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+@WebMvcTest(controllers = [InternalClientUserController::class, UserController::class])
+@Import(InternalClientUserControllerTest.TestSecurityConfiguration::class)
+class InternalClientUserControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val objectMapper: ObjectMapper,
+    ) {
+        @MockBean
+        private lateinit var userService: UserService
+
+        @MockBean
+        private lateinit var tokenParsingUtils: TokenParsingUtils
+
+        @MockBean
+        private lateinit var jwtDecoder: JwtDecoder
+
+        @MockBean
+        private lateinit var sourceApplicationJwtConverter: SourceApplicationJwtConverter
+
+        @Test
+        fun `get returns user json when found`() {
+            val objectIdentifier = UUID.randomUUID()
+            whenever(userService.find(objectIdentifier)).thenReturn(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = "Ada Lovelace",
+                    email = "ada@example.no",
+                ),
+            )
+
+            mockMvc
+                .perform(
+                    get("/api/intern-klient/authorization/brukere/$objectIdentifier")
+                        .with(internalClientJwt()),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.objectIdentifier").value(objectIdentifier.toString()))
+                .andExpect(jsonPath("$.name").value("Ada Lovelace"))
+                .andExpect(jsonPath("$.email").value("ada@example.no"))
+        }
+
+        @Test
+        fun `get returns not found when user is missing`() {
+            val objectIdentifier = UUID.randomUUID()
+            whenever(userService.find(objectIdentifier)).thenReturn(null)
+
+            mockMvc
+                .perform(
+                    get("/api/intern-klient/authorization/brukere/$objectIdentifier")
+                        .with(internalClientJwt()),
+                ).andExpect(status().isNotFound)
+        }
+
+        @Test
+        fun `lookup returns matching users only`() {
+            val first = UUID.randomUUID()
+            val second = UUID.randomUUID()
+            val third = UUID.randomUUID()
+            whenever(userService.findAllByObjectIdentifiers(listOf(first, second, third))).thenReturn(
+                listOf(
+                    User(objectIdentifier = first, name = "Ada Lovelace"),
+                    User(objectIdentifier = third, name = "Grace Hopper"),
+                ),
+            )
+
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/brukere/actions/lookup")
+                        .with(internalClientJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(listOf(first, second, third))),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].objectIdentifier").value(first.toString()))
+                .andExpect(jsonPath("$[0].name").value("Ada Lovelace"))
+                .andExpect(jsonPath("$[1].objectIdentifier").value(third.toString()))
+                .andExpect(jsonPath("$[1].name").value("Grace Hopper"))
+        }
+
+        @Test
+        fun `lookup returns empty list for empty input`() {
+            whenever(userService.findAllByObjectIdentifiers(emptyList())).thenReturn(emptyList())
+
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/brukere/actions/lookup")
+                        .with(internalClientJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(emptyList<UUID>())),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.length()").value(0))
+        }
+
+        @Test
+        fun `lookup returns bad request for invalid json`() {
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/brukere/actions/lookup")
+                        .with(internalClientJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{invalid"),
+                ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `internal client endpoint returns unauthorized without authorization header`() {
+            mockMvc
+                .perform(get("/api/intern-klient/authorization/brukere/${UUID.randomUUID()}"))
+                .andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        fun `internal client endpoint rejects ordinary user token`() {
+            mockMvc
+                .perform(
+                    get("/api/intern-klient/authorization/brukere/${UUID.randomUUID()}")
+                        .with(userJwt()),
+                ).andExpect(status().isForbidden)
+        }
+
+        @Test
+        fun `admin users endpoint still works for admins`() {
+            whenever(tokenParsingUtils.isAdmin(any())).thenReturn(true)
+            whenever(userService.getAll(any())).thenReturn(PageImpl(emptyList()))
+
+            mockMvc
+                .perform(
+                    get("/api/intern/authorization/users")
+                        .with(adminJwt()),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.content.length()").value(0))
+        }
+
+        @Test
+        fun `admin users endpoint still requires admin`() {
+            whenever(tokenParsingUtils.isAdmin(any())).thenReturn(false)
+
+            mockMvc
+                .perform(
+                    get("/api/intern/authorization/users")
+                        .with(userJwt()),
+                ).andExpect(status().isForbidden)
+        }
+
+        private fun internalClientJwt() =
+            jwt().authorities(SimpleGrantedAuthority("CLIENT_ID_fint-flyt-authorization-oauth2-client"))
+
+        private fun userJwt() = jwt().authorities(SimpleGrantedAuthority("ROLE_USER"))
+
+        private fun adminJwt() =
+            jwt().authorities(
+                SimpleGrantedAuthority("ROLE_USER"),
+                SimpleGrantedAuthority("ROLE_ADMIN"),
+            )
+
+        @TestConfiguration
+        class TestSecurityConfiguration {
+            @Bean
+            @Order(1)
+            fun internalClientApiFilterChain(http: HttpSecurity): SecurityFilterChain {
+                return http
+                    .securityMatcher("/api/intern-klient/**")
+                    .csrf { it.disable() }
+                    .oauth2ResourceServer { it.jwt {} }
+                    .authorizeHttpRequests {
+                        it.anyRequest().hasAuthority("CLIENT_ID_fint-flyt-authorization-oauth2-client")
+                    }.build()
+            }
+
+            @Bean
+            @Order(2)
+            fun internalApiFilterChain(http: HttpSecurity): SecurityFilterChain {
+                return http
+                    .securityMatcher("/api/intern/**")
+                    .csrf { it.disable() }
+                    .oauth2ResourceServer { it.jwt {} }
+                    .authorizeHttpRequests {
+                        it.anyRequest().hasAuthority("ROLE_USER")
+                    }.build()
+            }
+
+            @Bean
+            @Order(3)
+            fun fallbackFilterChain(http: HttpSecurity): SecurityFilterChain {
+                return http
+                    .securityMatcher("/**")
+                    .csrf { it.disable() }
+                    .authorizeHttpRequests { it.anyRequest().denyAll() }
+                    .build()
+            }
+        }
+    }


### PR DESCRIPTION
> [!IMPORTANT]
> Må deployes manuelt til 1 og 1 namespace/fylke med ca 5 minutters mellomrom for å avlaste NAM 

## Summary
- add INTERNAL_CLIENT_API endpoints for single and batch user lookup by objectIdentifier
- configure authorization-service's internal client OAuth2 client and app-specific client-id property
- add MockMvc coverage for lookup behavior, security behavior, and admin API regression

## Validation
- ./gradlew --no-daemon ktlintCheck
- ./gradlew --no-daemon test