### PR TITLE
Make authorization OAuth client optional

### DIFF
--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -59,6 +59,7 @@ spec:
         secretKeyRef:
           name: fint-flyt-authorization-oauth2-client
           key: fint.sso.client-id
+          optional: true
   resources:
     limits:
       memory: "1024Mi"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ novari:
       security:
         api:
           internal-client:
-            authorized-client-ids: ${fint.flyt.authorization.sso.client-id}
+            authorized-client-ids: ${fint.flyt.authorization.sso.client-id:}
 
 spring:
   profiles:


### PR DESCRIPTION
## Summary

Make the authorization OAuth client optional during startup so the service can restart even if the NAM-created client Secret has been removed.

The internal client API and existing OAuth client resource are kept in place. When `fint.flyt.authorization.sso.client-id` is missing, the authorized client ID list now resolves to an empty value instead of failing property resolution, and Kubernetes no longer blocks Pod startup on the missing Secret key.

Validation: `./gradlew check`