### PR TITLE
FFS-2054: Gjenopprett UserService.find etter parallell merge

### DIFF
--- a/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
@@ -10,6 +10,7 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 @Service
 class UserService(
@@ -49,6 +50,10 @@ class UserService(
             )
             mapFromEntity(existing)
         }
+    }
+
+    fun find(objectIdentifier: UUID): User? {
+        return userRepository.findByObjectIdentifier(objectIdentifier)?.let(::mapFromEntity)
     }
 
     fun findAllByObjectIdentifiers(objectIdentifiers: Collection<UUID>): List<User> {


### PR DESCRIPTION
## Summary

- Etter at PR #63 (race-fix ved opprettelse) ble merget, feilet `main` umiddelbart med `gradle clean check`: `Unresolved reference 'UUID'` og `Unresolved reference 'find'`.
- Rotårsak: PR #63 og PR #64 (FFS-2114, internal client user lookup) ble begge grenet ut fra samme commit og endret `UserService.kt` uten tekstlig overlapp, så GitHub merget begge uten konfliktvarsel. Resultatet var likevel semantisk ødelagt — PR #63 fjernet `find(objectIdentifier)` og `UUID`-importen den brukte, mens PR #64 la til `InternalClientUserController` som avhenger av nettopp den metoden.
- Legger `find(objectIdentifier: UUID): User?` tilbake i `UserService` som et rent oppslag for `InternalClientUserController`. Metoden er uavhengig av `findOrCreate`, som fortsatt håndterer selvbetjent opprettelse ved innlogging.
- `./gradlew clean check` er verifisert grønt lokalt.

Jira: FFS-2054