### PR TITLE
FFS-2115: Synk navn og epost fra token ved eksisterende bruker

### DIFF
--- a/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
@@ -38,7 +38,7 @@ class UserService(
 
     fun findOrCreate(user: User): User {
         userRepository.findByObjectIdentifier(user.objectIdentifier)?.let {
-            return mapFromEntity(it)
+            return mapFromEntity(syncNameAndEmail(it, user))
         }
 
         return try {
@@ -84,6 +84,22 @@ class UserService(
         }
 
         userRepository.saveAll(entities)
+    }
+
+    private fun syncNameAndEmail(
+        entity: UserEntity,
+        user: User,
+    ): UserEntity {
+        var changed = false
+        if (!user.name.isNullOrBlank() && user.name != entity.name) {
+            entity.name = user.name
+            changed = true
+        }
+        if (!user.email.isNullOrBlank() && user.email != entity.email) {
+            entity.email = user.email
+            changed = true
+        }
+        return if (changed) userRepository.save(entity) else entity
     }
 
     private fun mapFromUser(user: User): UserEntity {

--- a/src/test/kotlin/no/novari/flyt/authorization/user/UserEntityAuditingTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/UserEntityAuditingTest.kt
@@ -80,20 +80,24 @@ class UserEntityAuditingTest
             val auditReader = AuditReaderFactory.get(entityManager)
             val revisions = auditReader.getRevisions(UserEntity::class.java, createdUser.id)
 
-            assertEquals(listOf(1L, 2L), revisions)
-            assertEquals(listOf(1L), auditReader.find(UserEntity::class.java, createdUser.id, 1).sourceApplicationIds)
+            assertEquals(2, revisions.size)
+            val (firstRevision, secondRevision) = revisions
+            assertEquals(
+                listOf(1L),
+                auditReader.find(UserEntity::class.java, createdUser.id, firstRevision).sourceApplicationIds,
+            )
             assertEquals(
                 listOf(1L, 2L),
-                auditReader.find(UserEntity::class.java, createdUser.id, 2).sourceApplicationIds,
+                auditReader.find(UserEntity::class.java, createdUser.id, secondRevision).sourceApplicationIds,
             )
 
             assertEquals(
                 Actor.User(creatorOid),
-                auditReader.findRevision(ActorRevisionEntity::class.java, 1).actor,
+                auditReader.findRevision(ActorRevisionEntity::class.java, firstRevision).actor,
             )
             assertEquals(
                 Actor.User(editorOid),
-                auditReader.findRevision(ActorRevisionEntity::class.java, 2).actor,
+                auditReader.findRevision(ActorRevisionEntity::class.java, secondRevision).actor,
             )
 
             val persistedUser = userRepository.findById(createdUser.id!!).orElseThrow()
@@ -101,6 +105,69 @@ class UserEntityAuditingTest
             assertEquals(Actor.User(editorOid), persistedUser.lastModifiedBy)
             assertNotNull(persistedUser.createdAt)
             assertNotNull(persistedUser.lastModifiedAt)
+        }
+
+        @Test
+        fun `persists name and email revisions with actor metadata`() {
+            val creatorOid = UUID.randomUUID()
+            val editorOid = UUID.randomUUID()
+
+            authenticateAs(creatorOid)
+
+            val createdUser =
+                userRepository.saveAndFlush(
+                    UserEntity(
+                        objectIdentifier = UUID.randomUUID(),
+                        email = "original@example.no",
+                        name = "Original Name",
+                        sourceApplicationIds = mutableListOf(1L),
+                    ),
+                )
+
+            TestTransaction.flagForCommit()
+            TestTransaction.end()
+
+            TestTransaction.start()
+
+            authenticateAs(editorOid)
+
+            val updatedUser = userRepository.findById(checkNotNull(createdUser.id)).orElseThrow()
+            updatedUser.name = "Updated Name"
+            updatedUser.email = "updated@example.no"
+            userRepository.saveAndFlush(updatedUser)
+
+            TestTransaction.flagForCommit()
+            TestTransaction.end()
+
+            TestTransaction.start()
+            entityManager.clear()
+
+            val auditReader = AuditReaderFactory.get(entityManager)
+            val revisions = auditReader.getRevisions(UserEntity::class.java, createdUser.id)
+
+            assertEquals(2, revisions.size)
+            val (firstRevisionNumber, secondRevisionNumber) = revisions
+
+            val firstRevision = auditReader.find(UserEntity::class.java, createdUser.id, firstRevisionNumber)
+            assertEquals("Original Name", firstRevision.name)
+            assertEquals("original@example.no", firstRevision.email)
+
+            val secondRevision = auditReader.find(UserEntity::class.java, createdUser.id, secondRevisionNumber)
+            assertEquals("Updated Name", secondRevision.name)
+            assertEquals("updated@example.no", secondRevision.email)
+
+            assertEquals(
+                Actor.User(creatorOid),
+                auditReader.findRevision(ActorRevisionEntity::class.java, firstRevisionNumber).actor,
+            )
+            assertEquals(
+                Actor.User(editorOid),
+                auditReader.findRevision(ActorRevisionEntity::class.java, secondRevisionNumber).actor,
+            )
+
+            val persistedUser = userRepository.findById(createdUser.id!!).orElseThrow()
+            assertEquals(Actor.User(creatorOid), persistedUser.createdBy)
+            assertEquals(Actor.User(editorOid), persistedUser.lastModifiedBy)
         }
 
         private fun authenticateAs(oid: UUID) {

--- a/src/test/kotlin/no/novari/flyt/authorization/user/UserServiceTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/UserServiceTest.kt
@@ -25,7 +25,7 @@ class UserServiceTest {
     private val actorDisplayResolver = ActorDisplayResolver(ActorNameLookup { emptyMap() }, ActorDisplayProperties())
 
     @Test
-    fun `findOrCreate returns existing user without inserting or publishing`() {
+    fun `findOrCreate does not save when token name and email match stored values`() {
         val objectIdentifier = UUID.randomUUID()
         val existing =
             UserEntity(
@@ -46,15 +46,119 @@ class UserServiceTest {
             service.findOrCreate(
                 User(
                     objectIdentifier = objectIdentifier,
-                    name = "From token",
-                    email = "token@novari.no",
+                    name = "Existing",
+                    email = "existing@novari.no",
                     sourceApplicationIds = listOf(1L),
                 ),
             )
 
         assertEquals(objectIdentifier, result.objectIdentifier)
         assertEquals("Existing", result.name)
+        verify(repository, never()).save(any<UserEntity>())
         verify(repository, never()).saveAndFlush(any<UserEntity>())
+        verify(producer, never()).send(any())
+    }
+
+    @Test
+    fun `findOrCreate updates name and email when they differ from stored values`() {
+        val objectIdentifier = UUID.randomUUID()
+        val existing =
+            UserEntity(
+                objectIdentifier = objectIdentifier,
+                name = "Existing",
+                email = "existing@novari.no",
+                sourceApplicationIds = mutableListOf(1L),
+            ).apply { id = 1L }
+
+        val repository =
+            mock<UserRepository> {
+                on { findByObjectIdentifier(objectIdentifier) } doReturn existing
+                on { save(any<UserEntity>()) } doAnswer { it.arguments[0] as UserEntity }
+            }
+        val producer = mock<UserPermissionEntityProducerService>()
+        val service = UserService(repository, producer, actorDisplayResolver)
+
+        val result =
+            service.findOrCreate(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = "From token",
+                    email = "token@novari.no",
+                    sourceApplicationIds = listOf(1L),
+                ),
+            )
+
+        assertEquals("From token", result.name)
+        assertEquals("token@novari.no", result.email)
+        verify(repository).save(existing)
+        verify(producer, never()).send(any())
+    }
+
+    @Test
+    fun `findOrCreate preserves stored name when token name is blank`() {
+        val objectIdentifier = UUID.randomUUID()
+        val existing =
+            UserEntity(
+                objectIdentifier = objectIdentifier,
+                name = "Manually corrected name",
+                email = "existing@novari.no",
+                sourceApplicationIds = mutableListOf(1L),
+            ).apply { id = 1L }
+
+        val repository =
+            mock<UserRepository> {
+                on { findByObjectIdentifier(objectIdentifier) } doReturn existing
+            }
+        val producer = mock<UserPermissionEntityProducerService>()
+        val service = UserService(repository, producer, actorDisplayResolver)
+
+        val result =
+            service.findOrCreate(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = "",
+                    email = "existing@novari.no",
+                    sourceApplicationIds = listOf(1L),
+                ),
+            )
+
+        assertEquals("Manually corrected name", result.name)
+        verify(repository, never()).save(any<UserEntity>())
+        verify(producer, never()).send(any())
+    }
+
+    @Test
+    fun `findOrCreate updates email while preserving blank token name`() {
+        val objectIdentifier = UUID.randomUUID()
+        val existing =
+            UserEntity(
+                objectIdentifier = objectIdentifier,
+                name = "Manually corrected name",
+                email = "old@novari.no",
+                sourceApplicationIds = mutableListOf(1L),
+            ).apply { id = 1L }
+
+        val repository =
+            mock<UserRepository> {
+                on { findByObjectIdentifier(objectIdentifier) } doReturn existing
+                on { save(any<UserEntity>()) } doAnswer { it.arguments[0] as UserEntity }
+            }
+        val producer = mock<UserPermissionEntityProducerService>()
+        val service = UserService(repository, producer, actorDisplayResolver)
+
+        val result =
+            service.findOrCreate(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    name = null,
+                    email = "new@novari.no",
+                    sourceApplicationIds = listOf(1L),
+                ),
+            )
+
+        assertEquals("Manually corrected name", result.name)
+        assertEquals("new@novari.no", result.email)
+        verify(repository).save(existing)
         verify(producer, never()).send(any())
     }
 


### PR DESCRIPTION
## Summary

- `UserService.findOrCreate` synker nå `name`/`email` fra JWT-tokenet inn i eksisterende `UserEntity` når verdiene avviker fra det som er lagret, slik at endringer fanges opp av eksisterende Envers-audit (`user_entity_aud`) og dermed gir grunnlag for endringsloggen i FFS-2085.
- Blanke/manglende token-verdier (f.eks. når `displayname`-claimet mangler) overskriver aldri en lagret verdi, per felt uavhengig. Dette bevarer tilfeller der navn har vært satt manuelt i databasen fordi tokenet ikke inneholdt claimet.
- Ingen Kafka-republisering ved navn/epost-endring, siden `UserPermission`-DTOen kun inneholder `objectIdentifier` og `sourceApplicationIds`.
- Ingen endringer i `MeController`, `TokenParsingUtils` eller Envers-oppsettet var nødvendig — disse var allerede riktig konfigurert.

Relatert til [FFS-2115](https://novari-iks.atlassian.net/browse/FFS-2115), del av arbeidet mot [FFS-2085](https://novari-iks.atlassian.net/browse/FFS-2085).

[FFS-2115]: https://novari-iks.atlassian.net/browse/FFS-2115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FFS-2085]: https://novari-iks.atlassian.net/browse/FFS-2085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ