### PR TITLE
FFS-2154: Endre Page<> response i authorization-service

### DIFF
--- a/src/main/kotlin/no/novari/flyt/authorization/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/GlobalExceptionHandler.kt
@@ -1,0 +1,72 @@
+package no.novari.flyt.authorization
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ResponseStatusException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @ExceptionHandler(ResponseStatusException::class)
+    fun handleResponseStatusException(exception: ResponseStatusException): ProblemDetail {
+        logger.warn("Response status exception with status={}", exception.statusCode, exception)
+        return exception.reason
+            ?.let { ProblemDetail.forStatusAndDetail(exception.statusCode, it) }
+            ?: ProblemDetail.forStatus(exception.statusCode)
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadable(exception: HttpMessageNotReadableException): ProblemDetail {
+        logger.warn("Malformed request body", exception)
+        return createProblemDetail(
+            status = HttpStatus.BAD_REQUEST,
+            title = "Bad Request",
+            detail = "Malformed request body",
+        )
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleMethodArgumentTypeMismatch(exception: MethodArgumentTypeMismatchException): ProblemDetail {
+        logger.warn("Request parameter type mismatch", exception)
+        return createProblemDetail(
+            status = HttpStatus.BAD_REQUEST,
+            title = "Bad Request",
+            detail = "Invalid value for request parameter '${exception.name}'",
+        )
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(exception: IllegalArgumentException): ProblemDetail {
+        logger.warn("Invalid or incomplete authentication token", exception)
+        return createProblemDetail(
+            status = HttpStatus.BAD_REQUEST,
+            title = "Bad Request",
+            detail = "Invalid or incomplete authentication token",
+        )
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnhandledException(exception: Exception): ProblemDetail {
+        logger.error("Unhandled exception", exception)
+        return createProblemDetail(
+            status = HttpStatus.INTERNAL_SERVER_ERROR,
+            title = "Internal Server Error",
+            detail = "An unexpected error occurred",
+        )
+    }
+
+    private fun createProblemDetail(
+        status: HttpStatus,
+        title: String,
+        detail: String,
+    ): ProblemDetail =
+        ProblemDetail.forStatusAndDetail(status, detail).apply {
+            this.title = title
+        }
+}

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/UserController.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/UserController.kt
@@ -3,8 +3,8 @@ package no.novari.flyt.authorization.user.controller
 import no.novari.flyt.authorization.user.UserService
 import no.novari.flyt.authorization.user.controller.utils.TokenParsingUtils
 import no.novari.flyt.authorization.user.model.User
+import no.novari.flyt.authorization.user.model.UserPageResponse
 import no.novari.flyt.webresourceserver.UrlPaths.INTERNAL_API
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
@@ -25,15 +25,20 @@ class UserController(
     private val userService: UserService,
 ) {
     @GetMapping
-    fun get(
+    fun getUsers(
         authentication: Authentication?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(defaultValue = "name") sort: String,
-    ): Page<User> {
+    ): UserPageResponse {
         requireAdmin(authentication)
 
-        return userService.getAll(PageRequest.of(page, size, Sort.by(sort)))
+        val users = userService.getAll(PageRequest.of(page, size, Sort.by(sort)))
+
+        return UserPageResponse(
+            content = users.content,
+            totalPages = users.totalPages,
+        )
     }
 
     @PostMapping("actions/userPermissionBatchPut")

--- a/src/main/kotlin/no/novari/flyt/authorization/user/model/UserPageResponse.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/model/UserPageResponse.kt
@@ -1,0 +1,6 @@
+package no.novari.flyt.authorization.user.model
+
+data class UserPageResponse(
+    val content: List<User>,
+    val totalPages: Int,
+)

--- a/src/test/kotlin/no/novari/flyt/authorization/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,80 @@
+package no.novari.flyt.authorization
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+class GlobalExceptionHandlerTest {
+    private val mockMvc: MockMvc =
+        MockMvcBuilders
+            .standaloneSetup(ThrowingController())
+            .setControllerAdvice(GlobalExceptionHandler())
+            .build()
+
+    @Test
+    fun `response status exception preserves status and reason as problem detail`() {
+        mockMvc
+            .perform(get("/test/response-status-forbidden"))
+            .andExpect(status().isForbidden)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(403))
+            .andExpect(jsonPath("$.detail").value("No access"))
+    }
+
+    @Test
+    fun `illegal argument returns 400 without leaking internal message`() {
+        mockMvc
+            .perform(get("/test/illegal-argument"))
+            .andExpect(status().isBadRequest)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.detail").value("Invalid or incomplete authentication token"))
+    }
+
+    @Test
+    fun `path variable type mismatch returns 400 problem detail`() {
+        mockMvc
+            .perform(get("/test/path/not-a-number"))
+            .andExpect(status().isBadRequest)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.detail").value("Invalid value for request parameter 'id'"))
+    }
+
+    @Test
+    fun `unhandled exception returns generic 500 problem detail`() {
+        mockMvc
+            .perform(get("/test/generic"))
+            .andExpect(status().isInternalServerError)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(500))
+            .andExpect(jsonPath("$.detail").value("An unexpected error occurred"))
+    }
+
+    @RestController
+    private class ThrowingController {
+        @GetMapping("/test/response-status-forbidden")
+        fun responseStatus(): Nothing = throw ResponseStatusException(HttpStatus.FORBIDDEN, "No access")
+
+        @GetMapping("/test/illegal-argument")
+        fun illegalArgument(): Nothing = throw IllegalArgumentException("Missing token claim: objectIdentifier")
+
+        @GetMapping("/test/generic")
+        fun generic(): Nothing = throw RuntimeException("boom")
+
+        @GetMapping("/test/path/{id}")
+        fun path(
+            @PathVariable id: Long,
+        ): Long = id
+    }
+}


### PR DESCRIPTION
## Sammendrag
- Erstatter `Page<User>` i brukerliste-endepunktet med en stabil DTO `UserPageResponse` (`content`, `totalPages` – feltene frontend leser). Fjerner ustabil `PageImpl`-serialisering; feltnavn bevart → frontend upåvirket. Metoden er omdøpt `get` → `getUsers`.
- Legger til en ny `GlobalExceptionHandler` (`@RestControllerAdvice`) som svarer med `ProblemDetail` (`application/problem+json`) – tjenesten hadde ingen global feilhåndtering fra før:
  - `ResponseStatusException` bevarer status (401/403/404).
  - `IllegalArgumentException` fra token-parsing → 400 (lekket tidligere som 500 med stacktrace).
  - `HttpMessageNotReadableException` og `MethodArgumentTypeMismatchException` → 400.
  - catch-all → 500 uten stacktrace.
- Frontend er upåvirket: brukertilgang-skjermen leser ikke feilkroppen (bruker en lokal melding).