### PR TITLE
FFS-2180: Legg til batch-autorisering for source applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Spring Boot service that persists Flyt user permissions, answers client authoriz
 
 - **Internal OAuth2 APIs** — web-resource-server profile locks down `/api/intern/authorization` for users/admins and `/api/intern-klient/authorization/users` for authorized OAuth2 clients.
 - **Kafka request/reply** — listens for `client-id` authorization requests and replies with source application mappings using the FINT Kafka request/reply utilities.
-- **Permission sync** — persists users in Postgres and emits `userpermission` entity events whenever users are created, updated, or bulk-synced.
+- **Permission sync** — persists users in Postgres and emits `userpermission` entity events whenever users are created, updated, or bulk-synced. The topic is retained for services that have not yet migrated to HTTP authorization.
 - **Permission auditing** — keeps an Envers history of `user_entity` and `sourceApplicationIds` changes in dedicated audit tables with actor metadata.
 - **Role-gated onboarding** — accepts users only when their token roles match a configured allow-list and auto-grants admins access to all source applications.
 - **Scheduled publishing** — optional scheduler republishes all user permissions on a fixed delay to keep downstream caches in sync.
@@ -47,11 +47,15 @@ Base path: `/api/intern-klient/authorization/users`
 | --- | --- | --- | --- | --- |
 | `GET` | `/{objectIdentifier}` | Returns a single `User` by object identifier. | – | `200 OK` with `User` JSON or `404 Not Found`. |
 | `POST` | `/actions/lookup` | Returns all matching users for a batch of object identifiers. | JSON array of UUIDs. | `200 OK` with `List<User>`. |
+| `POST` | `/actions/authorize-source-applications` | Returns the requested source-application IDs the identified user is allowed to access. Unknown users and no matches return an empty set. | `{ "objectIdentifier": "<uuid>", "sourceApplicationIds": [1, 2, 3] }` | `200 OK` with `{ "authorizedSourceApplicationIds": [1, 3] }`. |
+
+`sourceApplicationIds` is represented as a set in the API model: duplicate JSON array values are ignored, and the
+response contains only requested, permitted IDs.
 
 ## Kafka Integration
 
 - **Request/reply consumer** — provisions the `authorization` request topic (resource `authorization`, parameter `client-id`) with 10-minute retention and responds with `ClientAuthorization` payloads for known SSO client IDs.
-- **Entity producer** — publishes `userpermission` entity events (partition count: 1, last/null-value retention: 4 days) whenever users are saved or bulk-updated; replay is also triggered by the scheduled publisher.
+- **Entity producer** — publishes `userpermission` entity events (partition count: 1, last/null-value retention: 4 days) whenever users are saved or bulk-updated; replay is also triggered by the scheduled publisher. This remains for backward compatibility while consumers migrate to the HTTP endpoint.
 - Topic names are built with `orgId`/`domainContext` prefixes from `novari.kafka.topic.*` and the FINT Kafka templating services.
 
 ## Scheduled Tasks
@@ -153,4 +157,3 @@ The script injects namespace-specific values (base paths, Kafka topics, authoriz
 4. Add or adjust tests for any new behaviour or edge cases.
 
 FINT Flyt Authorization Service is maintained by the FINT Flyt team. Reach out via the internal Slack channel or open an issue in this repository for questions or enhancements.
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
+    implementation("no.novari:flyt-web-resource-server:4.0.0")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
 
-    implementation("no.novari:flyt-web-resource-server:3.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
     implementation("no.novari:flyt-audit-starter:1.0.0")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")

--- a/src/main/kotlin/no/novari/flyt/authorization/user/UserRepository.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/UserRepository.kt
@@ -2,6 +2,8 @@ package no.novari.flyt.authorization.user
 
 import no.novari.flyt.authorization.user.model.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -10,4 +12,18 @@ interface UserRepository : JpaRepository<UserEntity, Long> {
     fun findByObjectIdentifier(sub: UUID): UserEntity?
 
     fun findAllByObjectIdentifierIn(objectIdentifiers: Collection<UUID>): List<UserEntity>
+
+    @Query(
+        """
+        SELECT sourceApplicationId
+        FROM UserEntity user
+        JOIN user.sourceApplicationIds sourceApplicationId
+        WHERE user.objectIdentifier = :objectIdentifier
+          AND sourceApplicationId IN :sourceApplicationIds
+        """,
+    )
+    fun findAuthorizedSourceApplicationIds(
+        @Param("objectIdentifier") objectIdentifier: UUID,
+        @Param("sourceApplicationIds") sourceApplicationIds: Set<Long>,
+    ): Set<Long>
 }

--- a/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
@@ -59,6 +59,17 @@ class UserService(
         return userRepository.findByObjectIdentifier(objectIdentifier)?.let(::mapFromEntity)
     }
 
+    fun findAuthorizedSourceApplicationIds(
+        objectIdentifier: UUID,
+        sourceApplicationIds: Set<Long>,
+    ): Set<Long> {
+        if (sourceApplicationIds.isEmpty()) {
+            return emptySet()
+        }
+
+        return userRepository.findAuthorizedSourceApplicationIds(objectIdentifier, sourceApplicationIds)
+    }
+
     fun findAllByObjectIdentifiers(objectIdentifiers: Collection<UUID>): List<User> {
         return mapAllFromEntities(userRepository.findAllByObjectIdentifierIn(objectIdentifiers))
     }

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
@@ -1,6 +1,8 @@
 package no.novari.flyt.authorization.user.controller
 
 import no.novari.flyt.authorization.user.UserService
+import no.novari.flyt.authorization.user.controller.model.SourceApplicationAuthorizationRequest
+import no.novari.flyt.authorization.user.controller.model.SourceApplicationAuthorizationResponse
 import no.novari.flyt.authorization.user.model.User
 import no.novari.flyt.webresourceserver.UrlPaths.INTERNAL_CLIENT_API
 import org.springframework.http.HttpStatus
@@ -31,5 +33,26 @@ class InternalClientUserController(
         @RequestBody objectIdentifiers: List<UUID>,
     ): List<User> {
         return userService.findAllByObjectIdentifiers(objectIdentifiers)
+    }
+
+    @PostMapping("/actions/authorize-source-applications")
+    fun authorizeSourceApplications(
+        @RequestBody request: SourceApplicationAuthorizationRequest,
+    ): SourceApplicationAuthorizationResponse {
+        if (request.sourceApplicationIds.isEmpty()) {
+            return SourceApplicationAuthorizationResponse(emptySet())
+        }
+
+        val authorizedSourceApplicationIds =
+            userService
+                .find(request.objectIdentifier)
+                ?.sourceApplicationIds
+                ?.toSet()
+                .orEmpty()
+
+        return SourceApplicationAuthorizationResponse(
+            request.sourceApplicationIds
+                .filterTo(mutableSetOf(), authorizedSourceApplicationIds::contains),
+        )
     }
 }

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserController.kt
@@ -44,15 +44,13 @@ class InternalClientUserController(
         }
 
         val authorizedSourceApplicationIds =
-            userService
-                .find(request.objectIdentifier)
-                ?.sourceApplicationIds
-                ?.toSet()
-                .orEmpty()
+            userService.findAuthorizedSourceApplicationIds(
+                request.objectIdentifier,
+                request.sourceApplicationIds,
+            )
 
         return SourceApplicationAuthorizationResponse(
-            request.sourceApplicationIds
-                .filterTo(mutableSetOf(), authorizedSourceApplicationIds::contains),
+            authorizedSourceApplicationIds,
         )
     }
 }

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/model/SourceApplicationAuthorization.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/model/SourceApplicationAuthorization.kt
@@ -1,0 +1,12 @@
+package no.novari.flyt.authorization.user.controller.model
+
+import java.util.UUID
+
+data class SourceApplicationAuthorizationRequest(
+    val objectIdentifier: UUID,
+    val sourceApplicationIds: Set<Long>,
+)
+
+data class SourceApplicationAuthorizationResponse(
+    val authorizedSourceApplicationIds: Set<Long>,
+)

--- a/src/test/kotlin/no/novari/flyt/authorization/WebResourceServerCompatibilityTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/WebResourceServerCompatibilityTest.kt
@@ -1,0 +1,43 @@
+package no.novari.flyt.authorization
+
+import no.novari.flyt.webresourceserver.security.AuthorityMappingService
+import no.novari.flyt.webresourceserver.security.AuthorizationServiceConfiguration
+import no.novari.flyt.webresourceserver.security.user.UserAuthorizationService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.web.client.RestClient
+import java.util.function.Supplier
+
+class WebResourceServerCompatibilityTest {
+    private val contextRunner =
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    OAuth2ClientAutoConfiguration::class.java,
+                    AuthorizationServiceConfiguration::class.java,
+                ),
+            ).withBean(AuthorityMappingService::class.java, Supplier { mock<AuthorityMappingService>() })
+            .withBean(RestClient.Builder::class.java, Supplier { RestClient.builder() })
+            .withPropertyValues(
+                "spring.security.oauth2.client.registration.authorization-service.client-id=authorization-client",
+                "spring.security.oauth2.client.registration.authorization-service.client-secret=secret",
+                "spring.security.oauth2.client.registration.authorization-service.authorization-grant-type=client_credentials",
+                "spring.security.oauth2.client.provider.authorization-service.token-uri=https://sso.example.no/token",
+                "novari.flyt.web-resource-server.security.authorization.base-url=https://authorization.example.no",
+            )
+
+    @Test
+    fun `loads web resource server authorization client configuration`() {
+        contextRunner.run { context ->
+            assertThat(context).hasSingleBean(ClientRegistrationRepository::class.java)
+            assertThat(context).hasSingleBean(OAuth2AuthorizedClientManager::class.java)
+            assertThat(context).hasSingleBean(UserAuthorizationService::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/no/novari/flyt/authorization/user/UserEntityAuditingTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/UserEntityAuditingTest.kt
@@ -170,6 +170,27 @@ class UserEntityAuditingTest
             assertEquals(Actor.User(editorOid), persistedUser.lastModifiedBy)
         }
 
+        @Test
+        fun `finds only requested authorized source application IDs`() {
+            val objectIdentifier = UUID.randomUUID()
+            authenticateAs(UUID.randomUUID())
+            userRepository.saveAndFlush(
+                UserEntity(
+                    objectIdentifier = objectIdentifier,
+                    sourceApplicationIds = mutableListOf(1L, 2L, 3L),
+                ),
+            )
+            entityManager.clear()
+
+            val result =
+                userRepository.findAuthorizedSourceApplicationIds(
+                    objectIdentifier,
+                    setOf(2L, 3L, 4L),
+                )
+
+            assertEquals(setOf(2L, 3L), result)
+        }
+
         private fun authenticateAs(oid: UUID) {
             val jwt =
                 Jwt

--- a/src/test/kotlin/no/novari/flyt/authorization/user/UserServiceTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/UserServiceTest.kt
@@ -25,6 +25,31 @@ class UserServiceTest {
     private val actorDisplayResolver = ActorDisplayResolver(ActorNameLookup { emptyMap() }, ActorDisplayProperties())
 
     @Test
+    fun `find authorized source application IDs queries only requested IDs`() {
+        val objectIdentifier = UUID.randomUUID()
+        val repository =
+            mock<UserRepository> {
+                on { findAuthorizedSourceApplicationIds(objectIdentifier, setOf(1L, 2L, 3L)) } doReturn setOf(2L, 3L)
+            }
+        val service = UserService(repository, mock(), actorDisplayResolver)
+
+        val result = service.findAuthorizedSourceApplicationIds(objectIdentifier, setOf(1L, 2L, 3L))
+
+        assertEquals(setOf(2L, 3L), result)
+        verify(repository).findAuthorizedSourceApplicationIds(objectIdentifier, setOf(1L, 2L, 3L))
+        verify(repository, never()).findByObjectIdentifier(any())
+    }
+
+    @Test
+    fun `find authorized source application IDs skips repository for empty input`() {
+        val repository = mock<UserRepository>()
+        val service = UserService(repository, mock(), actorDisplayResolver)
+
+        assertEquals(emptySet<Long>(), service.findAuthorizedSourceApplicationIds(UUID.randomUUID(), emptySet()))
+        verify(repository, never()).findAuthorizedSourceApplicationIds(any(), any())
+    }
+
+    @Test
     fun `findOrCreate does not save when token name and email match stored values`() {
         val objectIdentifier = UUID.randomUUID()
         val existing =

--- a/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
@@ -125,12 +125,12 @@ class InternalClientUserControllerTest
         @Test
         fun `authorize source applications returns the requested permitted IDs once`() {
             val objectIdentifier = UUID.randomUUID()
-            whenever(userService.find(objectIdentifier)).thenReturn(
-                User(
-                    objectIdentifier = objectIdentifier,
-                    sourceApplicationIds = listOf(2L, 3L, 4L),
+            whenever(
+                userService.findAuthorizedSourceApplicationIds(
+                    objectIdentifier,
+                    setOf(1L, 2L, 3L),
                 ),
-            )
+            ).thenReturn(setOf(2L, 3L))
 
             mockMvc
                 .perform(
@@ -154,7 +154,9 @@ class InternalClientUserControllerTest
         @Test
         fun `authorize source applications returns empty list for an unknown user`() {
             val objectIdentifier = UUID.randomUUID()
-            whenever(userService.find(objectIdentifier)).thenReturn(null)
+            whenever(
+                userService.findAuthorizedSourceApplicationIds(objectIdentifier, setOf(1L, 2L)),
+            ).thenReturn(emptySet())
 
             mockMvc
                 .perform(
@@ -176,12 +178,9 @@ class InternalClientUserControllerTest
         @Test
         fun `authorize source applications returns empty list when no requested ID is permitted`() {
             val objectIdentifier = UUID.randomUUID()
-            whenever(userService.find(objectIdentifier)).thenReturn(
-                User(
-                    objectIdentifier = objectIdentifier,
-                    sourceApplicationIds = listOf(4L),
-                ),
-            )
+            whenever(
+                userService.findAuthorizedSourceApplicationIds(objectIdentifier, setOf(1L, 2L)),
+            ).thenReturn(emptySet())
 
             mockMvc
                 .perform(
@@ -217,6 +216,27 @@ class InternalClientUserControllerTest
                         ),
                 ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.authorizedSourceApplicationIds.length()").value(0))
+        }
+
+        @Test
+        fun `authorize source applications returns unauthorized without authorization header`() {
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/users/actions/authorize-source-applications")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"objectIdentifier":"${UUID.randomUUID()}","sourceApplicationIds":[1]}"""),
+                ).andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        fun `authorize source applications rejects ordinary user token`() {
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/users/actions/authorize-source-applications")
+                        .with(userJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"objectIdentifier":"${UUID.randomUUID()}","sourceApplicationIds":[1]}"""),
+                ).andExpect(status().isForbidden)
         }
 
         @Test

--- a/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/authorization/user/controller/InternalClientUserControllerTest.kt
@@ -123,6 +123,103 @@ class InternalClientUserControllerTest
         }
 
         @Test
+        fun `authorize source applications returns the requested permitted IDs once`() {
+            val objectIdentifier = UUID.randomUUID()
+            whenever(userService.find(objectIdentifier)).thenReturn(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    sourceApplicationIds = listOf(2L, 3L, 4L),
+                ),
+            )
+
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/users/actions/authorize-source-applications")
+                        .with(internalClientJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """
+                            {
+                              "objectIdentifier": "$objectIdentifier",
+                              "sourceApplicationIds": [1, 2, 2, 3]
+                            }
+                            """.trimIndent(),
+                        ),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.authorizedSourceApplicationIds.length()").value(2))
+                .andExpect(jsonPath("$.authorizedSourceApplicationIds[0]").value(2))
+                .andExpect(jsonPath("$.authorizedSourceApplicationIds[1]").value(3))
+        }
+
+        @Test
+        fun `authorize source applications returns empty list for an unknown user`() {
+            val objectIdentifier = UUID.randomUUID()
+            whenever(userService.find(objectIdentifier)).thenReturn(null)
+
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/users/actions/authorize-source-applications")
+                        .with(internalClientJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """
+                            {
+                              "objectIdentifier": "$objectIdentifier",
+                              "sourceApplicationIds": [1, 2]
+                            }
+                            """.trimIndent(),
+                        ),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.authorizedSourceApplicationIds.length()").value(0))
+        }
+
+        @Test
+        fun `authorize source applications returns empty list when no requested ID is permitted`() {
+            val objectIdentifier = UUID.randomUUID()
+            whenever(userService.find(objectIdentifier)).thenReturn(
+                User(
+                    objectIdentifier = objectIdentifier,
+                    sourceApplicationIds = listOf(4L),
+                ),
+            )
+
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/users/actions/authorize-source-applications")
+                        .with(internalClientJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """
+                            {
+                              "objectIdentifier": "$objectIdentifier",
+                              "sourceApplicationIds": [1, 2]
+                            }
+                            """.trimIndent(),
+                        ),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.authorizedSourceApplicationIds.length()").value(0))
+        }
+
+        @Test
+        fun `authorize source applications returns empty list for empty input`() {
+            mockMvc
+                .perform(
+                    post("/api/intern-klient/authorization/users/actions/authorize-source-applications")
+                        .with(internalClientJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """
+                            {
+                              "objectIdentifier": "${UUID.randomUUID()}",
+                              "sourceApplicationIds": []
+                            }
+                            """.trimIndent(),
+                        ),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.authorizedSourceApplicationIds.length()").value(0))
+        }
+
+        @Test
         fun `lookup returns bad request for invalid json`() {
             mockMvc
                 .perform(


### PR DESCRIPTION
## Summary

Implements [FFS-2180](https://novari-iks.atlassian.net/browse/FFS-2180).

- Legger til OAuth2-klientbeskyttet batch-endepunkt for brukerens tillatte source-application-ID-er.
- Returnerer kun forespurte og faktisk tillatte ID-er, med tomt svar for ukjent bruker eller manglende tilgang.
- Beholder eksisterende publisering til `userpermission`-topicet mens øvrige konsumenter migreres.

[FFS-2180]: https://novari-iks.atlassian.net/browse/FFS-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ