### PR TITLE
FFS-2224 Aktiver sporing og JSON-logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,11 +52,13 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
     implementation("no.novari:flyt-audit-starter:1.0.0")
+    implementation("no.novari:telemetry-starter:0.0.3")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     compileOnly("org.springframework.security:spring-security-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
 
     implementation("org.springframework.kafka:spring-kafka")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 
     implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
     implementation("no.novari:flyt-audit-starter:1.0.0")
-    implementation("no.novari:telemetry-starter:0.0.4")
+    implementation("no.novari:telemetry-starter:0.0.5")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     runtimeOnly("org.postgresql:postgresql")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 
     implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
     implementation("no.novari:flyt-audit-starter:1.0.0")
-    implementation("no.novari:telemetry-starter:0.0.3")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     runtimeOnly("org.postgresql:postgresql")

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -73,6 +73,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/afk-no"
       - op: replace

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -64,6 +64,11 @@ patches:
             secretKeyRef:
               name: fint-flyt-isygraving-oauth2-client
               key: fint.flyt.isygraving.sso.client-id
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -78,6 +78,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/afk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/agderfk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -37,6 +37,12 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "agderfk-no"
       - op: add

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/agderfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -87,6 +87,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -92,6 +92,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/bfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -78,6 +78,11 @@ patches:
             secretKeyRef:
               name: fint-flyt-fskyss-oauth2-client
               key: fint.flyt.fskyss.sso.client-id
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bym.oslo.kommune.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bym-oslo-kommune-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -37,6 +37,12 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "ffk-no"
       - op: add

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -90,6 +90,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/fintlabs-no"
       - op: replace

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -76,6 +76,11 @@ patches:
             secretKeyRef:
               name: fint-flyt-eapply-oauth2-client
               key: fint.flyt.eapply.sso.client-id
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -37,6 +37,12 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "innlandetfylke-no"
       - op: add

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -57,6 +57,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/mrfylke-no"
       - op: replace

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -70,6 +70,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/nfk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -73,6 +73,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ofk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -78,6 +78,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ofk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -64,6 +64,11 @@ patches:
             secretKeyRef:
               name: fint-flyt-isygraving-oauth2-client
               key: fint.flyt.isygraving.sso.client-id
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/rogfk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -37,6 +37,12 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "rogfk-no"
       - op: add

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/rogfk-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -57,6 +57,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -62,6 +62,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
             secretKeyRef:
               name: fint-flyt-isygraving-oauth2-client
               key: fint.flyt.isygraving.sso.client-id
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -37,6 +37,12 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "tromsfylke-no"
       - op: add

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -37,6 +37,12 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "novari.kafka.topic.orgId"
          value: "trondelagfylke-no"
       - op: add

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -57,6 +57,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -48,6 +48,11 @@ patches:
             secretKeyRef:
               name: fint-flyt-isygraving-oauth2-client
               key: fint.flyt.isygraving.sso.client-id
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -62,6 +62,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vlfk-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -62,6 +62,11 @@ patches:
             secretKeyRef:
               name: fint-flyt-eapply-oauth2-client
               key: fint.flyt.eapply.sso.client-id
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
 
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -76,6 +76,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vlfk-no"
       - op: replace

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -38,6 +38,11 @@ $AUTHORIZED_ORG_ROLE_PAIRS$EXTRA_APP_PATCHES
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "$ORG_ID"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "$SERVLET_CONTEXT_PATH"
       - op: replace

--- a/script/render-overlay.sh
+++ b/script/render-overlay.sh
@@ -8,6 +8,21 @@ DEFAULT_TEMPLATE="$TEMPLATE_DIR/overlay.yaml.tpl"
 USER_ROLE_URL="USER"
 DEVELOPER_ROLE_URL="DEVELOPER"
 
+OTEL_ENDPOINT_BETA="http://alloy.flais-system.svc.cluster.local:4318"
+
+# Base-URL uten /v1/traces: telemetry-starter legger på signal-stien selv.
+# Settes manuelt inntil flaiserator har støtte for det, og kun i beta der Alloy kjører.
+build_otel_env_patch() {
+  local env_path="$1"
+
+  if [[ "$env_path" != "beta" ]]; then
+    return
+  fi
+
+  printf '      - op: add\n        path: "/spec/env/-"\n        value:\n          name: "OTEL_EXPORTER_OTLP_ENDPOINT"\n          value: "%s"' \
+    "$OTEL_ENDPOINT_BETA"
+}
+
 extra_user_orgs_for_namespace() {
   local namespace="$1"
   case "$namespace" in
@@ -285,12 +300,17 @@ while IFS= read -r file; do
     EXTRA_CLIENT_ID_ENV_PATCHES="${EXTRA_CLIENT_ID_ENV_PATCHES%$'\n'}"
   fi
 
+  OTEL_ENV_PATCH="$(build_otel_env_patch "$env_path")"
+
   EXTRA_APP_PATCHES=""
   if [[ -n "$EXTRA_ENV_PATCHES" ]]; then
     EXTRA_APP_PATCHES+=$'\n'"$EXTRA_ENV_PATCHES"
   fi
   if [[ -n "$EXTRA_CLIENT_ID_ENV_PATCHES" ]]; then
     EXTRA_APP_PATCHES+=$'\n'"$EXTRA_CLIENT_ID_ENV_PATCHES"
+  fi
+  if [[ -n "$OTEL_ENV_PATCH" ]]; then
+    EXTRA_APP_PATCHES+=$'\n'"$OTEL_ENV_PATCH"
   fi
   if [[ -n "$EXTRA_APP_PATCHES" ]]; then
     EXTRA_APP_PATCHES+=$'\n'

--- a/src/main/kotlin/no/novari/flyt/authorization/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/GlobalExceptionHandler.kt
@@ -1,6 +1,6 @@
 package no.novari.flyt.authorization
 
-import org.slf4j.LoggerFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -11,11 +11,15 @@ import org.springframework.web.server.ResponseStatusException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
-    private val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+    private val log = KotlinLogging.logger {}
 
     @ExceptionHandler(ResponseStatusException::class)
     fun handleResponseStatusException(exception: ResponseStatusException): ProblemDetail {
-        logger.warn("Response status exception with status={}", exception.statusCode, exception)
+        log.atWarn {
+            message = "Response status exception with status={}"
+            arguments = arrayOf(exception.statusCode)
+            cause = exception
+        }
         return exception.reason
             ?.let { ProblemDetail.forStatusAndDetail(exception.statusCode, it) }
             ?: ProblemDetail.forStatus(exception.statusCode)
@@ -23,7 +27,10 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadable(exception: HttpMessageNotReadableException): ProblemDetail {
-        logger.warn("Malformed request body", exception)
+        log.atWarn {
+            message = "Malformed request body"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.BAD_REQUEST,
             title = "Bad Request",
@@ -33,7 +40,10 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
     fun handleMethodArgumentTypeMismatch(exception: MethodArgumentTypeMismatchException): ProblemDetail {
-        logger.warn("Request parameter type mismatch", exception)
+        log.atWarn {
+            message = "Request parameter type mismatch"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.BAD_REQUEST,
             title = "Bad Request",
@@ -43,7 +53,10 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(exception: IllegalArgumentException): ProblemDetail {
-        logger.warn("Invalid or incomplete authentication token", exception)
+        log.atWarn {
+            message = "Invalid or incomplete authentication token"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.BAD_REQUEST,
             title = "Bad Request",
@@ -53,7 +66,10 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception::class)
     fun handleUnhandledException(exception: Exception): ProblemDetail {
-        logger.error("Unhandled exception", exception)
+        log.atError {
+            message = "Unhandled exception"
+            cause = exception
+        }
         return createProblemDetail(
             status = HttpStatus.INTERNAL_SERVER_ERROR,
             title = "Internal Server Error",

--- a/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/UserService.kt
@@ -1,12 +1,11 @@
 package no.novari.flyt.authorization.user
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.audit.actor.ActorDisplayResolver
 import no.novari.flyt.authorization.user.kafka.UserPermission
 import no.novari.flyt.authorization.user.kafka.UserPermissionEntityProducerService
 import no.novari.flyt.authorization.user.model.User
 import no.novari.flyt.authorization.user.model.UserEntity
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -20,19 +19,27 @@ class UserService(
     private val userPermissionEntityProducerService: UserPermissionEntityProducerService,
     private val actorDisplayResolver: ActorDisplayResolver,
 ) {
+    private val log = KotlinLogging.logger {}
+
     fun publishUsers() {
-        logger.info("Starting publishing users")
+        log.atInfo { message = "Starting publishing users" }
         try {
             val userPermissions =
                 userRepository
                     .findAll()
                     .map(::mapFromEntityToUserPermission)
 
-            logger.info("Retrieved and mapped {} user entities", userPermissions.size)
+            log.atInfo {
+                message = "Retrieved and mapped {} user entities"
+                arguments = arrayOf(userPermissions.size)
+            }
             userPermissions.forEach(userPermissionEntityProducerService::send)
-            logger.info("Successfully published users")
+            log.atInfo { message = "Successfully published users" }
         } catch (exception: Exception) {
-            logger.error("Error while publishing users", exception)
+            log.atError {
+                message = "Error while publishing users"
+                cause = exception
+            }
         }
     }
 
@@ -47,10 +54,10 @@ class UserService(
             mapFromEntity(savedEntity)
         } catch (exception: DataIntegrityViolationException) {
             val existing = userRepository.findByObjectIdentifier(user.objectIdentifier) ?: throw exception
-            logger.info(
-                "Lost race when creating user with objectIdentifier={}; returning existing user",
-                user.objectIdentifier,
-            )
+            log.atInfo {
+                message = "Lost race when creating user with objectIdentifier={}; returning existing user"
+                arguments = arrayOf(user.objectIdentifier)
+            }
             mapFromEntity(existing)
         }
     }
@@ -164,9 +171,5 @@ class UserService(
             objectIdentifier = checkNotNull(userEntity.objectIdentifier),
             sourceApplicationIds = userEntity.sourceApplicationIds.toList(),
         )
-    }
-
-    private companion object {
-        val logger: Logger = LoggerFactory.getLogger(UserService::class.java)
     }
 }

--- a/src/main/kotlin/no/novari/flyt/authorization/user/controller/utils/TokenParsingUtils.kt
+++ b/src/main/kotlin/no/novari/flyt/authorization/user/controller/utils/TokenParsingUtils.kt
@@ -1,9 +1,9 @@
 package no.novari.flyt.authorization.user.controller.utils
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.authorization.user.AccessControlProperties
 import no.novari.flyt.authorization.user.model.User
 import no.novari.flyt.webresourceserver.security.user.UserClaim
-import org.slf4j.LoggerFactory
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.stereotype.Service
@@ -13,6 +13,8 @@ import java.util.UUID
 class TokenParsingUtils(
     private val accessControlProperties: AccessControlProperties,
 ) {
+    private val log = KotlinLogging.logger {}
+
     fun getObjectIdentifierFromToken(jwtAuthenticationToken: JwtAuthenticationToken): String {
         return requiredTokenAttribute(jwtAuthenticationToken, UserClaim.OBJECT_IDENTIFIER)
     }
@@ -37,13 +39,13 @@ class TokenParsingUtils(
     fun hasPermittedRole(jwtAuthenticationToken: JwtAuthenticationToken): Boolean {
         val roles = getRolesFromToken(jwtAuthenticationToken)
         if (roles.isEmpty()) {
-            logger.warn("Roles are null or empty in token")
+            log.atWarn { message = "Roles are null or empty in token" }
             return false
         }
 
         val permittedRoles = accessControlProperties.permittedAppRoles.values
         if (permittedRoles.isEmpty()) {
-            logger.warn("Permitted app roles are not configured or empty")
+            log.atWarn { message = "Permitted app roles are not configured or empty" }
             return false
         }
 
@@ -62,9 +64,5 @@ class TokenParsingUtils(
     ): String {
         return jwtAuthenticationToken.tokenAttributes[claim.tokenClaimName]?.toString()
             ?: throw IllegalArgumentException("Missing token claim: ${claim.tokenClaimName}")
-    }
-
-    private companion object {
-        val logger = LoggerFactory.getLogger(TokenParsingUtils::class.java)
     }
 }

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 spring:
   kafka:
     consumer:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,8 @@ novari:
             authorized-client-ids: ${fint.flyt.authorization.sso.client-id}
 
 spring:
+  application:
+    name: ${fint.application-id}
   profiles:
     include:
       - flyt-kafka

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Sammendrag

- Legger til `telemetry-starter` for HTTP-selvinstrumentering
- Bumper `flyt-web-resource-server` til versjon med Kafka-sporing (`novari.kafka.tracing.enabled=true`) og korrekt trace-propagering - denne appen brukte fint-kafka kun transitivt via web-resource-server (request/reply-autorisering av eksterne klienter)
- Legger til JSON-logging fra bunnen (var ikke i bruk fra før) med telemetry-starter sitt loggfragment, slik at `traceId`/`spanId` blir søkbare
- Konverterer eksisterende SLF4J-bruk (`GlobalExceptionHandler`, `UserService`, `TokenParsingUtils`) til `kotlin-logging`, samme mønster som `fint-flyt-file-service` og `fint-flyt-egrunnerverv-gateway` (egen commit)

Del av OpenTelemetry-tracing-epicen (FFS-2196), jf. rettet beslutning 13 i løsningsanalysen (Kafka-sporing skal på i alle utrullinger, ikke bare instance-service).