### PR TITLE
Behold isygraving for nfk-no ved rendring av overlays

### DIFF
--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -43,8 +43,8 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
-            name: "fint.flyt.side.available"
-            value: "true"
+          name: "fint.flyt.side.available"
+          value: "true"
       - op: add
         path: "/spec/env/-"
         value:
@@ -56,11 +56,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
-            name: "fint.flyt.side.sso.client-id"
-            valueFrom:
-                secretKeyRef:
-                    name: fint-flyt-side-oauth2-client
-                    key: fint.flyt.side.sso.client-id
+          name: "fint.flyt.side.sso.client-id"
+          valueFrom:
+            secretKeyRef:
+              name: fint-flyt-side-oauth2-client
+              key: fint.flyt.side.sso.client-id
 
       - op: add
         path: "/spec/env/-"

--- a/script/render-overlay.sh
+++ b/script/render-overlay.sh
@@ -62,7 +62,7 @@ extra_env_for_overlay() {
       printf 'fint.flyt.isygraving.available'
       ;;
     nfk-no:api)
-      printf 'fint.flyt.side.available'
+      printf 'fint.flyt.isygraving.available fint.flyt.side.available'
       ;;
     fintlabs-no:beta)
       printf 'fint.flyt.digisak.available fint.flyt.side.available fint.flyt.eapply.available'
@@ -90,7 +90,7 @@ extra_client_id_apps_for_overlay() {
       printf 'isygraving'
       ;;
     nfk-no:api)
-      printf 'side'
+      printf 'isygraving side'
       ;;
     fintlabs-no:beta)
       printf 'digisak side eapply'


### PR DESCRIPTION
## Sammendrag

`script/render-overlay.sh` genererte kun `side`-oppsettet for `nfk-no/api`, mens den committede overlayen også hadde `fint.flyt.isygraving.available` og tilhørende `fint.flyt.isygraving.sso.client-id`. Å kjøre skriptet fjernet dermed isygraving-konfigurasjonen fra produksjon.

Fikset ved å legge `isygraving` inn i `extra_env_for_overlay` og `extra_client_id_apps_for_overlay` for `nfk-no:api`, plassert først slik at rekkefølgen matcher den committede filen.

Verifisert med `kustomize build` at rendret output er **byte-identisk** før og etter. Eneste endring i den genererte filen er innrykk-normalisering av `side`-blokkene, som skriptet uansett skriver konsistent. Skriptet er nå idempotent for hele repoet.

## Til vurdering: manglende `isygraving-oauth2-client.yaml`

`nfk-no/api` refererer til secret `fint-flyt-isygraving-oauth2-client` via `secretKeyRef`, men har ikke `isygraving-oauth2-client.yaml` i `resources`. Alle andre org-ider som bruker isygraving (`afk-no`, `bfk-no`, `ofk-no`, `telemarkfylke-no`, `vestfoldfylke-no`) har den filen i overlayet sitt.

Jeg har bevisst **ikke** endret dette her, siden denne PR-en kun skal gjenopprette committed tilstand, og å legge til ressursen ville opprettet en ny ressurs i produksjon. Men det ser ut som en reell mangel — enten mangler ressursen, eller så er isygraving-env-variablene for `nfk-no` overflødige.