### PR TITLE
FFS-2234 Fjern patch mot fjernet ingress-rute

### DIFF
--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -23,9 +23,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/afk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/afk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -23,9 +23,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/afk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/afk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/agderfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/agderfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/agderfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/agderfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -24,9 +24,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/bfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/bfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -24,9 +24,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/bfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/bfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/bym-oslo-kommune-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/bym-oslo-kommune-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/ffk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/ffk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/ffk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/ffk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -24,9 +24,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/fintlabs-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/fintlabs-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/innlandetfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/innlandetfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/innlandetfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/innlandetfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -22,9 +22,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/mrfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/mrfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -22,9 +22,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/nfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/nfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -23,9 +23,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/ofk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/ofk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -23,9 +23,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/ofk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/ofk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/rogfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/rogfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/rogfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/rogfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -22,9 +22,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/telemarkfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/telemarkfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -22,9 +22,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/telemarkfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/telemarkfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/tromsfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/tromsfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/tromsfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/tromsfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/trondelagfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/trondelagfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/trondelagfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/trondelagfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -22,9 +22,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/vestfoldfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/vestfoldfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -22,9 +22,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/vestfoldfylke-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/vestfoldfylke-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/vlfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/vlfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -23,9 +23,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "/beta/vlfk-no/api/intern/authorization"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "/beta/vlfk-no/api/intern/authorization"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -21,9 +21,6 @@ patches:
       - op: replace
         path: "/spec/ingress/routes/0/path"
         value: "$INGRESS_BASE_PATH"
-      - op: replace
-        path: "/spec/ingress/routes/1/path"
-        value: "$INGRESS_BASE_PATH"
       - op: add
         path: "/spec/env/-"
         value:


### PR DESCRIPTION
## Sammendrag

Fjerner patchen mot `/spec/ingress/routes/1/path` fra `kustomize/templates/overlay.yaml.tpl` og fra alle 28 overlays.

## Bakgrunn

Da SSO-ruten ble fjernet fra `kustomize/base/flais.yaml` i formiddag, ble ikke indekseringen i overlayene oppdatert. Basen har nå én rute — indeks `0` — mens overlayene fortsatt patcher både `0` og `1`.

Resultatet er at `kubectl kustomize` avviser hele overlayet:

```
error: replace operation does not apply: doc is missing path: /spec/ingress/routes/1/path: missing value
```

Det slår ut i CD-steget «Bake manifests», før noe når clusteret. Alle 28 deploy-mål er rammet — fail-fast gjorde at bare det første synes i loggen.

## Verifisering

`kubectl kustomize` er kjørt på **samtlige 28 overlays** i dette repoet etter endringen. Alle baker grønt.

Endringen er også validert mot `script/render-overlay.sh`: en full re-rendering gir byte-identisk resultat med den kirurgiske fjerningen, så malen og de genererte overlayene er i takt.

Diffen er ren sletting — 29 filer, 0 tillegg, 87 slettede linjer.

Se [FFS-2234](https://novari-iks.atlassian.net/browse/FFS-2234).

[FFS-2234]: https://novari-iks.atlassian.net/browse/FFS-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ